### PR TITLE
Add an As method to convert between different types of string strings

### DIFF
--- a/StrongStrings.Test/Creation.cs
+++ b/StrongStrings.Test/Creation.cs
@@ -67,4 +67,7 @@ public class Creation
 
 	[TestMethod]
 	public void CanExplicitCastFromString() => Assert.AreEqual(expected: StrongYeet, actual: (StrongStringDerivedClass)Yeet);
+
+	[TestMethod]
+	public void CanConvert() => _ = StrongYeet.As<NonEmptyStrongString>();
 }

--- a/StrongStrings/AnyStrongString.cs
+++ b/StrongStrings/AnyStrongString.cs
@@ -18,6 +18,10 @@ using System.Text;
 [DebuggerDisplay(value: $"{{{nameof(GetDebuggerDisplay)}(),nq}}")]
 public abstract record AnyStrongString : IString
 {
+	public TDest As<TDest>()
+		where TDest : AnyStrongString
+		=> FromString<TDest>(WeakString);
+
 	public char[] ToCharArray() => ToCharArray(strongString: this);
 
 	// IString implementation


### PR DESCRIPTION
This replaces the ugly `(DerviedClass)(string)thing` pattern with `thing.As<DerviedClass>()`